### PR TITLE
Refactor tensor initialization to use register_buffer

### DIFF
--- a/src/models/components/gnn.py
+++ b/src/models/components/gnn.py
@@ -72,14 +72,15 @@ class GlobalGNN(nn.Module):
                     input_size, self.D, self.num_hidden_decoder, self.num_layers_decoder
                 )
 
-            self.temporal_freqs = (
-                torch.arange(1, self.num_temporal_freqs + 1, device="cuda") * torch.pi
-            )
+            self.register_buffer(
++               "temporal_freqs",
++               torch.arange(1, self.num_temporal_freqs + 1) * torch.pi,
++           )
             
-        self.B = (
-            torch.randn((self.D, self.num_spatial_samples), device="cuda")
-            * self.spatial_feat_scale
-        )
+        self.register_buffer(
++           "B",
++           torch.randn((self.D, self.num_spatial_samples)) * self.spatial_feat_scale,
++       )
     
     def embed_source(self, source_samples, cond=None):        
         if len(source_samples.shape) > 2:

--- a/src/models/components/gnn.py
+++ b/src/models/components/gnn.py
@@ -51,8 +51,9 @@ class GlobalGNN(nn.Module):
                 input_size, self.D, self.num_hidden_decoder, self.num_layers_decoder
             )
 
-            self.temporal_freqs = (
-                torch.arange(1, self.num_temporal_freqs + 1, device="cuda") * torch.pi
+            self.register_buffer(
+                "temporal_freqs",
+                torch.arange(1, self.num_temporal_freqs + 1) * torch.pi,
             )
         else:
             input_size = (


### PR DESCRIPTION
Hey,

Thank you for providing the Meta Flow Matching code.

I noticed that there are random tensors initialized in the model that are not part of the checkpoints/state dict, so I changed them to use `register_buffer`.